### PR TITLE
[fix-math]: fix maths library configuration - Do Not Merge

### DIFF
--- a/markdown_preview.py
+++ b/markdown_preview.py
@@ -792,7 +792,7 @@ class MarkdownCompiler(Compiler):
             # Ensure extension is in correct format and separate config from extension
             if isinstance(e, str):
                 ext = e
-                config = OrderedDict()
+                config = OrderedDict(extensions[e])
             elif isinstance(e, (dict, OrderedDict)):
                 ext = list(e.keys())[0]
                 config = list(e.values())[0]


### PR DESCRIPTION
This PR aims to only discuss about the markdownPreview configuration since I had to tweak the code in order to render Katex or MathJax formula

- For Katex
	+ Configuration specified in the documentation should be correctly parsed

	```json
	"markdown_extensions": {
	    "pymdownx.arithmatex": {
	        "generic": true,
	    }
	}
	```

	+  We should, in order to render the extension_config as `{'pymdownx.arithmatex': OrderedDict([('generic', True)])}`:
		* either do this changes (accept the value `if isinstance(e, str):` https://github.com/facelessuser/MarkdownPreview/blob/master/markdown_preview.py#L793)
		* OR not iterating on extensions' object properties (removing the `for e in extensions` loop https://github.com/facelessuser/MarkdownPreview/blob/master/markdown_preview.py#L791
	+ here is my KateX configuration

	```json
	"js": [
	    "https://cdn.jsdelivr.net/npm/katex@0.10.0-alpha/dist/katex.min.js",
	    "res://MarkdownPreview/js/katex_config.js"
	],
	"css": [
	    "default",                                                           
	    "https://cdn.jsdelivr.net/npm/katex@0.10.0-alpha/dist/katex.min.css", 
	    "res://MarkdownPreview/css/katex_eqnum.css"
	],
	"markdown_extensions": {
	    "pymdownx.arithmatex": {
	        "generic": true,
	    }
	}
	```


- For MathJax
	+ the mathjax rendering doesn't work unless you specify the `type="text/x-mathjax-config"` attribute in the `<script>` tag, which is not done in the `get_javascript` method https://github.com/facelessuser/MarkdownPreview/blob/master/markdown_preview.py#L281
	+ here is my mathjax configuration

	```json
	"js": [
	    "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js",
		"res://MarkdownPreview/js/math_config.js"
	],
	```

For Both libraries: is there any problems in my configuration ? because the code doesn't seems to work without modifying the code
 
