### PR TITLE
[fix-doc]: correct documentation on maths library configuration

### DIFF
--- a/docs/src/markdown/extras.md
+++ b/docs/src/markdown/extras.md
@@ -25,11 +25,13 @@ To load MathJax support, simply include the MathJax library along with the math 
 If you are using `pymdownx.arithmatex` you can configure it like so to take advantage of the generalized configuration.  You are also free to customize Arithmatex to your liking, though you may have to modify your MathJax config to accommodate certain changes. Check out Arithmatex documentation for more info.
 
 ```js
-    "markdown_extensions": {
-        "pymdownx.arithmatex": {
-            "generic": true
+    "markdown_extensions": [
+        {
+            "pymdownx.arithmatex": {
+                "generic": true,
+            },
         }
-    }
+    ]
 ```
 
 ## KaTeX Support
@@ -67,11 +69,13 @@ You also must provide the KaTeX CSS file. Optionally, if you'd like equation num
 If you are using `pymdownx.arithmatex` you can configure it like so to take advantage of the generalized configuration.  You are also free to customize Arithmatex to your liking, though you may have to modify your KaTeX config to accommodate certain changes. Check out Arithmatex documentation for more info.
 
 ```js
-    "markdown_extensions": {
-        "pymdownx.arithmatex": {
-            "generic": true
+    "markdown_extensions": [
+        {
+            "pymdownx.arithmatex": {
+                "generic": true,
+            },
         }
-    }
+    ]
 ```
 
 ## UML Support

--- a/samples/sample.md
+++ b/samples/sample.md
@@ -73,7 +73,7 @@ Also, any indented block is considered a code block.  If `enable_highlight` is `
 
 ## Math
 
-When `enable_mathjax` is `true`, inline math can be included \\(\frac{\pi}{2}\\) $\pi$
+When specific library to display Maths in the browser (e.g: MathJax or KaTeX) are correctly set through `"js"`, `"css"` and `"markdown_extensions"` configuration field, inline math can be included \\(\frac{\pi}{2}\\) $\pi$
 
 Alternatively, math can be written on its own line:
 

--- a/samples/sample.md
+++ b/samples/sample.md
@@ -73,7 +73,7 @@ Also, any indented block is considered a code block.  If `enable_highlight` is `
 
 ## Math
 
-When specific library to display Maths in the browser (e.g: MathJax or KaTeX) are correctly set through `"js"`, `"css"` and `"markdown_extensions"` configuration field, inline math can be included \\(\frac{\pi}{2}\\) $\pi$
+Math can be displayed in the browser using MathJax or Katex. The feature can be enabled by correctly configuring the `"js"`, `"css"`, and `"markdown_extensions"` configuration fields. This allows for inline math to be included \\(\frac{\pi}{2}\\) $\pi$.
 
 Alternatively, math can be written on its own line:
 


### PR DESCRIPTION
TODO: this should also be done with all remaining `enable_`configuration
(e.g: `enable_uml` which seems also deprecated)