### PR TITLE
Prepare for new dependencies

### DIFF
--- a/MarkdownPreview.sublime-settings
+++ b/MarkdownPreview.sublime-settings
@@ -72,12 +72,12 @@
         // You can't include "extra" and "superfences"
         // as "fenced_code" can not be included with "superfences",
         // so we include the pieces separately.
-        "markdown.extensions.smart_strong",
         "markdown.extensions.footnotes",
         "markdown.extensions.attr_list",
         "markdown.extensions.def_list",
         "markdown.extensions.tables",
         "markdown.extensions.abbr",
+        "pymdownx.betterem",
         {
             "markdown.extensions.codehilite": {
                 "guess_lang": false
@@ -101,7 +101,22 @@
         "markdown.extensions.admonition",
 
         // PyMdown extensions that help give a GitHub-ish feel
-        "pymdownx.superfences",  // Nested fences and UML support
+        {
+            "pymdownx.superfences": { // Nested fences and UML support
+                "custom_fences": [
+                    {
+                        "name": "flow",
+                        "class": "uml-flowchart",
+                        "format": {"!!python/name": "pymdownx.superfences.fence_code_format"}
+                    },
+                    {
+                        "name": "sequence",
+                        "class": "uml-sequence-diagram",
+                        "format": {"!!python/name": "pymdownx.superfences.fence_code_format"}
+                    }
+                ]
+            }
+        },
         {
             "pymdownx.magiclink": {   // Auto linkify URLs and email addresses
                 "repo_url_shortener": true,

--- a/docs/src/markdown/changes.md
+++ b/docs/src/markdown/changes.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2.2.1
+
+- Add support for Markdown 3+ and Pymdownx 6+.
+- Add viewport scaling in HTML.
+
 ## 2.2.0
 
 - Add basic GitLab support.

--- a/examples/test.md
+++ b/examples/test.md
@@ -63,7 +63,14 @@
                 image_path: https://assets-cdn.github.com/images/icons/emoji/unicode/
                 non_standard_image_path: https://assets-cdn.github.com/images/icons/emoji/
           - pymdownx.tasklist
-          - pymdownx.superfences
+          - pymdownx.superfences:
+              custom_fences:
+                - name: flow
+                  class: uml-flowchart
+                  format: !!python/name:pymdownx.superfences.fence_code_format
+                - name: sequence
+                  class: uml-sequence-diagram
+                  format: !!python/name:pymdownx.superfences.fence_code_format
 ---
 test: This tests the meta extension
 title: This title will be overridden by YAML

--- a/markdown_wrapper.py
+++ b/markdown_wrapper.py
@@ -26,14 +26,14 @@ class StMarkdown(Markdown):
         We are overriding this in order to gracefully handle bad extensions
         and to prevent old deprecated style of 'extensions(option=value)'.
         """
-        MD3 = version_info[0] > 2
+        md3 = version_info[0] > 2
         for ext in extensions:
             try:
                 # Make sure we aren't using old form `extension(option=value)`
                 if isinstance(ext, util.string_type) and ('(' not in ext):
                     ext = self.build_extension(ext, configs.get(ext, []))
                 if isinstance(ext, Extension):
-                    if MD3:
+                    if md3:
                         ext._extendMarkdown(self)
                     else:
                         ext.extendMarkdown(self, globals())

--- a/markdown_wrapper.py
+++ b/markdown_wrapper.py
@@ -1,7 +1,7 @@
 """Markdown Preview wrapper."""
 from __future__ import absolute_import
 import traceback
-from markdown import Markdown, util
+from markdown import Markdown, util, version_info
 from markdown.extensions import Extension
 
 
@@ -26,13 +26,17 @@ class StMarkdown(Markdown):
         We are overriding this in order to gracefully handle bad extensions
         and to prevent old deprecated style of 'extensions(option=value)'.
         """
+        MD3 = version_info[0] > 2
         for ext in extensions:
             try:
                 # Make sure we aren't using old form `extension(option=value)`
                 if isinstance(ext, util.string_type) and ('(' not in ext):
                     ext = self.build_extension(ext, configs.get(ext, []))
                 if isinstance(ext, Extension):
-                    ext.extendMarkdown(self, globals())
+                    if MD3:
+                        ext._extendMarkdown(self)
+                    else:
+                        ext.extendMarkdown(self, globals())
                 elif ext is not None:
                     raise TypeError(
                         'Extension "%s.%s" must be of type: "markdown.Extension"'


### PR DESCRIPTION
Use `betterem` as `smart_strong` has been removed in Python Markdown 3.0 and is enabled by default.  But since we can't conditionally include an extension based on version, just use `betterem` which gives us the same (similar) behavior before and after Markdown 3. Also explicitly include superfences formatters as they are no longer defined by default in pymdownx 6.0, but defining them explicitly is backwards compatible.

Hopefully this will allow us to have a smooth transition when I update the `markdown` and `pymdownx` dependencies.  They must be upgraded at the same time.