### PR TITLE
Fixed hard coded package name on markdown_preview.py

### DIFF
--- a/markdown_preview.py
+++ b/markdown_preview.py
@@ -122,7 +122,7 @@ def load_utf8(filename):
 def load_resource(name):
     """Return file contents for files within the package root folder."""
     try:
-        return sublime.load_resource('Packages/MarkdownPreview/{0}'.format(name))
+        return sublime.load_resource('Packages/{}/{}'.format(__package__, name))
     except Exception:
         log("Error while load_resource('%s')" % name)
         traceback.print_exc()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
-ignore=D202,D203,D401
+ignore=D202,D203,D401,W504
 max-line-length=120
 exclude=desktop/*,site/*.py


### PR DESCRIPTION
Less code to refactor in the future, in case the package changes name.