### PR TITLE
Easier to read

### DIFF
--- a/css/github.css
+++ b/css/github.css
@@ -11,6 +11,8 @@ body {
     width: 980px;
     margin-right: auto;
     margin-left: auto;
+    color:#333;
+    background:#fff;
 }
 
 body .markdown-body {


### PR DESCRIPTION
CSS did not include foreground/background pair of colours of the body. In some configurations this makes it very hard to read (because the browser may rely on system colours, like mine does).
WCAG rule: never specify a foreground colour (here in .markdown-body) without a background colour.