### PR TITLE
Fixed obvious typo

### DIFF
--- a/markdown_preview.py
+++ b/markdown_preview.py
@@ -1167,7 +1167,7 @@ class MarkdownPreviewCommand(sublime_plugin.TextCommand):
             cmd = '"%s" %s' % (browser, path)
             if sys.platform == 'darwin':
                 cmd = "open -a %s" % cmd
-            elif sys.platform == 'linux2':
+            elif sys.platform == 'linux':
                 cmd += ' &'
             elif sys.platform == 'win32':
                 cmd = 'start "" %s' % cmd


### PR DESCRIPTION
Fixed typo that prevents Linux from being recognized as platform and starting the preview as background process, thus freezing Sublime while the preview is open.

resolves #72