### PR TITLE
update image path for gemoji

### DIFF
--- a/MarkdownPreview.sublime-settings
+++ b/MarkdownPreview.sublime-settings
@@ -140,8 +140,8 @@
                         "height": "20px",
                         "width": "20px"
                     },
-                    "image_path": "https://assets-cdn.github.com/images/icons/emoji/unicode/",
-                    "non_standard_image_path": "https://assets-cdn.github.com/images/icons/emoji/"
+                    "image_path": "https://github.githubassets.com/images/icons/emoji/unicode/",
+                    "non_standard_image_path": "https://github.githubassets.com/images/icons/emoji/"
                 }
             }
         }


### PR DESCRIPTION
The previous image patch aren't working anymore and I updated them with the current ones that github is using.