### PR TITLE
Fix typo in markdown.extensions.toc config example

### DIFF
--- a/docs/src/markdown/usage.md
+++ b/docs/src/markdown/usage.md
@@ -180,7 +180,7 @@ So let's pretend we didn't like Toc's default slugify `markdown.extensions.heade
     "markdown_extensions": [
         {
             "markdown.extensions.toc": {
-                "slugify": {"!!python/name", "pymdownx.slugs.uslugify"}
+                "slugify": {"!!python/name": "pymdownx.slugs.uslugify"}
             }
         }
     ]


### PR DESCRIPTION
I think that is the correct way... or at least is how I made it work in my config.