### PR TITLE
Exclude docs/ directory from packed .sublime-package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 # Auto detect text files and perform LF normalization
 * text=auto
 *.css linguist-detectable=false
+
+docs/ export-ignore


### PR DESCRIPTION
Would you mind removing the `docs/` directory from the `.sublime-package` to reduce the file size from 1.7MB to 220KB? `docs/` are not compiled, they are not that useful in the `.sublime-package` imho, but they greatly increase the package size.