### PR TITLE
Added configurable Gitlab domain.

### DIFF
--- a/MarkdownPreview.sublime-settings
+++ b/MarkdownPreview.sublime-settings
@@ -188,6 +188,13 @@
     "github_inject_header_ids": false,
 
     /*
+        Uses a custom Gitlab domain to access the GitLab API, this enables you to use an on-premises enterprise Gitlab deployment.
+        This does require that you set a gitlab_personal_token with at least `api` access.
+        In case this URL is not provided it defaults to "https://gitlab.com/api/v4/markdown".
+    */
+    // "gitlab_url": "https://gitlab.mycompany.com/api/v4/markdown",
+
+    /*
         Uses an OAuth token when parsing markdown with GitHub API. To create one for Markdown Preview, see https://help.github.com/articles/creating-an-oauth-token-for-command-line-use.
         Warn: this secret *must not be shared* with anyone and at least you should create it with minimal scopes for security reasons.
     */
@@ -198,6 +205,7 @@
         Warn: this secret *must not be shared* with anyone and at least you should create it with minimal scopes for security reasons.
     */
     // "gitlab_personal_token": "secret",
+
 
     /*
         Sets the default css file to embed in the HTML

--- a/markdown_preview.py
+++ b/markdown_preview.py
@@ -794,7 +794,7 @@ class GitlabCompiler(OnlineCompiler):
     ]
     compiler_name = "gitlab"
     content_type = "application/json"
-    url = "https://gitlab.com/api/v4/markdown"
+    url = self.settings.get("gitlab_url", "https://gitlab.com/api/v4/markdown")
     authentication_settings_key = "gitlab_personal_token"
     authentication_api_key = "Private-Token"
     authentication_api_type = ""


### PR DESCRIPTION
This (partially) closes issues #44 . I have only a Gitlab custom domain to test with, so that's why I cannot provide a similar change for the Github part.