### PR TITLE
Support expanding variables and home dir in path_tempfile

### DIFF
--- a/MarkdownPreview.sublime-settings
+++ b/MarkdownPreview.sublime-settings
@@ -306,6 +306,9 @@
         the OS default. The directory will be created if it doesn't exist yet.
         Relative paths are supported and are checked against `os.path.isabs`,
         see docs: http://docs.python.org/3/library/os.path.html#os.path.isabs
+        Environment variables and user "~" placeholder are supported.
+        see docs: https://docs.python.org/3/library/os.path.html#os.path.expanduser
+        see docs: https://docs.python.org/3/library/os.path.html#os.path.expandvars
 
         Examples: /tmp/custom_folder   (Linux/macOS - absolute path)
                     C:/TEMP/MYNOTES

--- a/docs/src/markdown/usage.md
+++ b/docs/src/markdown/usage.md
@@ -129,6 +129,9 @@ via the `path_tempfile` option:
         using LiveReload and don't want to use the OS default. The directory will be created if it
         doesn't exist. Relative paths are supported, and are checked against `os.path.isabs`, see
         doc: http://docs.python.org/3/library/os.path.html#os.path.isabs
+        Environment variables and user "~" placeholder are supported.
+        see docs: https://docs.python.org/3/library/os.path.html#os.path.expanduser
+        see docs: https://docs.python.org/3/library/os.path.html#os.path.expandvars
 
         Examples: /tmp/custom_folder   (Linux/OSX - absolute path)
                     C:/TEMP/MYNOTES

--- a/markdown_preview.py
+++ b/markdown_preview.py
@@ -90,22 +90,28 @@ def request_url(url, data, headers):
 
 def get_temp_preview_path(view):
     """Return a permanent full path of the temp markdown preview file."""
-    settings = sublime.load_settings('MarkdownPreview.sublime-settings')
-
-    tmp_filename = '%s.html' % view.id()
-    if settings.get('path_tempfile'):
-        if os.path.isabs(settings.get('path_tempfile')):  # absolute path or not
-            tmp_dir = settings.get('path_tempfile')
-        else:
-            tmp_dir = os.path.join(os.path.dirname(view.file_name()), settings.get('path_tempfile'))
-    else:
-        tmp_dir = tempfile.gettempdir()
-
+    tmp_dir = get_temp_preview_dir(view)
     if not os.path.isdir(tmp_dir):  # create directory if not exists
         os.makedirs(tmp_dir)
 
+    tmp_filename = '%s.html' % view.id()
     tmp_fullpath = os.path.join(tmp_dir, tmp_filename)
     return tmp_fullpath
+
+
+def get_temp_preview_dir(view):
+    """Return a permanent full dir of the temp markdown preview file."""
+    settings = sublime.load_settings('MarkdownPreview.sublime-settings')
+    path_tempfile = settings.get('path_tempfile')
+    if path_tempfile:
+        if os.path.isabs(path_tempfile):  # absolute path or not
+            tmp_dir = path_tempfile
+        else:
+            tmp_dir = os.path.join(os.path.dirname(view.file_name()), path_tempfile)
+    else:
+        tmp_dir = tempfile.gettempdir()
+
+    return tmp_dir
 
 
 def save_utf8(filename, text):

--- a/markdown_preview.py
+++ b/markdown_preview.py
@@ -104,6 +104,7 @@ def get_temp_preview_dir(view):
     settings = sublime.load_settings('MarkdownPreview.sublime-settings')
     path_tempfile = settings.get('path_tempfile')
     if path_tempfile:
+        path_tempfile = filter_path(path_tempfile)
         if os.path.isabs(path_tempfile):  # absolute path or not
             tmp_dir = path_tempfile
         else:
@@ -112,6 +113,14 @@ def get_temp_preview_dir(view):
         tmp_dir = tempfile.gettempdir()
 
     return tmp_dir
+
+
+def filter_path(path):
+    """Return a path with user and variables expanded."""
+    path = os.path.expanduser(path)
+    path = os.path.expandvars(path)
+
+    return path
 
 
 def save_utf8(filename, text):


### PR DESCRIPTION
Support expand env vars and home user in path_tempfile.

This allows you specify paths with `~` and variables like `$HOME`:

    "path_tempfile": "~/.cache/markdownpreview"

- refactor: get temp preview path
