### PR TITLE
add 25px margin at both sides on github css window browser.

### DIFF
--- a/css/github.css
+++ b/css/github.css
@@ -119,7 +119,7 @@
 
 body {
     max-width: 980px;
-    margin: 16px auto;
+    margin: 16px 25px;
     background-color: var(--color-canvas-default);
 }
 


### PR DESCRIPTION
Hello, i've just added 25px margin at both sides to make it looks better and do not crop the Heading icons.
