### PR TITLE
Clarify gitlab access token in MarkdownPreview.sublime-settings

### DIFF
--- a/MarkdownPreview.sublime-settings
+++ b/MarkdownPreview.sublime-settings
@@ -215,7 +215,7 @@
     // "github_oauth_token": "secret",
 
     /*
-        Use a personal access token to parse GitLab Flavored Markdown with
+        Use a personal access token with `read_api` scope to parse GitLab Flavored Markdown with
         the GitLab API. For info on token creation, see this page:
         https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html
 


### PR DESCRIPTION
Specify that the gitlab access token needs `read_api` scope.

Source of information: https://gitlab.com/gitlab-org/gitlab/-/issues/372855

I and another contributor have verified that this works; see https://github.com/facelessuser/MarkdownPreview/issues/187.