### PR TITLE
Fix invalid f-string syntax

### DIFF
--- a/markdown_preview.py
+++ b/markdown_preview.py
@@ -591,7 +591,7 @@ class Compiler(object):
             html += self.get_javascript()
             html += self.get_highlight()
             html += self.get_title()
-            html += f'</head><body data-theme="{self.settings.get('theme', 'auto')}">'
+            html += f'</head><body data-theme="{self.settings.get("theme", "auto")}">'
             html += '<article class="markdown-body">'
             html += body
             html += '</article>'


### PR DESCRIPTION
Latest ST3 branch release (2.8.1) produces:

```
Traceback (most recent call last):
  File "C:\Program Files\Sublime Text\Lib\python33\sublime_plugin.py", line 308, in reload_plugin
    m = importlib.import_module(modulename)
  File "./python3.3/importlib/__init__.py", line 90, in import_module
  File "<frozen importlib._bootstrap>", line 1584, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1565, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1532, in _find_and_load_unlocked
  File "C:\Program Files\Sublime Text\Lib\python33\sublime_plugin.py", line 1635, in load_module
    exec(compile(source, source_path, 'exec'), mod.__dict__)
  File "C:\Users\fauxpark\AppData\Roaming\Sublime Text 3\Installed Packages\MarkdownPreview.sublime-package\markdown_preview.py", line 594
    html += f'</head><body data-theme="{self.settings.get('theme', 'auto')}">'
                                                          ^
SyntaxError: invalid syntax
```

Lint also caught this: https://github.com/facelessuser/MarkdownPreview/actions/runs/23368106195